### PR TITLE
Use a different variable for the config baseURL

### DIFF
--- a/server.cfg
+++ b/server.cfg
@@ -47,7 +47,7 @@ seta wh_check_fov "0"
 
 // HTTP downloads
 seta sv_wwwDownload "0"	// server does a www dl redirect
-seta sv_wwwBaseURL "%CONF_REDIR%" // base URL for redirect
+seta sv_wwwBaseURL "%CONF_NETREDIR%" // base URL for redirect
 seta sv_wwwDlDisconnected "0" // tell clients to perform their downloads while disconnected from the server
 seta sv_wwwFallbackURL ""// URL to send to if an http/ftp fails or is refused client side
 


### PR DESCRIPTION
This is so that clients can fetch from a different source to the server init scripts (which come from loopback)